### PR TITLE
Handle missing player in SQUAD_CREATED event

### DIFF
--- a/squad-server/index.js
+++ b/squad-server/index.js
@@ -156,6 +156,23 @@ export default class SquadServer extends EventEmitter {
 
     this.rcon.on('SQUAD_CREATED', async (data) => {
       data.player = await this.getPlayerByEOSID(data.playerEOSID, true);
+      if (!data.player) {
+        for (const [key, value] of Object.entries(data)) {
+          if (key.startsWith('player') && key.endsWith('ID') && key !== 'playerEOSID') {
+            data.player = await this.getPlayerByAnyID(value, true);
+            if (data.player) break;
+          }
+        }
+        if (!data.player) {
+          Logger.verbose(
+            'SquadServer',
+            1,
+            'Warning: Could not resolve player for SQUAD_CREATED event',
+            data
+          );
+          return;
+        }
+      }
       data.player.squadID = data.squadID;
 
       delete data.playerName;

--- a/squad-server/plugins/discord-squad-created.js
+++ b/squad-server/plugins/discord-squad-created.js
@@ -46,6 +46,7 @@ export default class DiscordSquadCreated extends DiscordBasePlugin {
   }
 
   async onSquadCreated(info) {
+    if (!info.player) return;
     if (this.options.useEmbed) {
       await this.sendDiscordMessage({
         embed: {
@@ -72,7 +73,7 @@ export default class DiscordSquadCreated extends DiscordBasePlugin {
       });
     } else {
       await this.sendDiscordMessage(
-        ` \`\`\`Oyuncu: ${info.player.name}\n Kurduğu squad ${info.player.squadID} : ${info.squadName}\n Takım :  ${info.teamName}\`\`\` ` // 
+        ` \`\`\`Oyuncu: ${info.player.name}\n Kurduğu squad ${info.player.squadID} : ${info.squadName}\n Takım :  ${info.teamName}\`\`\` ` //
       );
     }
   }


### PR DESCRIPTION
## Summary
- Guard against missing player when a squad is created by attempting to resolve via any ID and logging a warning if not found
- Avoid setting squad ID when player resolution fails and skip event emission
- Ensure Discord squad creation plugin safely handles events without player data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint --fix squad-server/index.js squad-server/plugins/discord-squad-created.js`
- `npx prettier --write squad-server/index.js squad-server/plugins/discord-squad-created.js`


------
https://chatgpt.com/codex/tasks/task_e_689cd89da710832eac0823e3dc5428e5