### PR TITLE
Handle missing player info in squad baiting

### DIFF
--- a/squad-server/plugins/squad-baiting.js
+++ b/squad-server/plugins/squad-baiting.js
@@ -346,6 +346,15 @@ export default class SquadBaiting extends DiscordBasePlugin {
         this.resetPlayerCounters(steamID)
     }
     async onPlayerConnected(info) {
+        if (!info.player) {
+            if (info.eosID) {
+                info.player = await this.server.getPlayerByEOSID(info.eosID, true);
+            }
+            if (!info.player) {
+                this.verbose(1, 'Player data missing; aborting baiting logic');
+                return;
+            }
+        }
         const { steamID, name: playerName, teamID } = info.player;
         this.resetPlayerCounters(steamID)
     }


### PR DESCRIPTION
## Summary
- Ensure `onPlayerConnected` gracefully handles missing `info.player`
- Attempt to refresh player data with `getPlayerByEOSID` before aborting

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cddcb79d8832eaf87079dd8913599