### PR TITLE
Handle missing player data in db log plugin

### DIFF
--- a/squad-server/plugins/db-log.js
+++ b/squad-server/plugins/db-log.js
@@ -674,11 +674,18 @@ export default class DBLog extends BasePlugin {
   }
 
   async onPlayerConnected(info) {
+    const player = info.player || (await this.server.getPlayerByEOSID(info.eosID, true));
+
+    if (!player) {
+      this.verbose(1, `Warning: Could not find player with EOSID ${info.eosID}`);
+      return;
+    }
+
     await this.models.Player.upsert(
       {
-        eosID: info.player.eosID,
-        steamID: info.player.steamID,
-        lastName: info.player.name,
+        eosID: player.eosID,
+        steamID: player.steamID,
+        lastName: player.name,
         lastIP: info.ip
       },
       {


### PR DESCRIPTION
## Summary
- gracefully fetch player details in DB logging when info.player is missing
- warn and exit early when player lookup fails

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint squad-server/plugins/db-log.js`
- `npx prettier squad-server/plugins/db-log.js -c`


------
https://chatgpt.com/codex/tasks/task_e_689ce85a24e8832eaa4fe7565ddf8ce5