### PR TITLE
Handle missing player data on disconnect in squad-baiting plugin

### DIFF
--- a/squad-server/plugins/squad-baiting.js
+++ b/squad-server/plugins/squad-baiting.js
@@ -347,6 +347,15 @@ export default class SquadBaiting extends DiscordBasePlugin {
     }
 
     async onPlayerDisconnected(info) {
+        if (!info.player) {
+            if (info.eosID) {
+                info.player = await this.server.getPlayerByEOSID(info.eosID, true);
+            }
+            if (!info.player) {
+                this.verbose(1, 'Player data missing; aborting baiting logic');
+                return;
+            }
+        }
         const { eosID, name: playerName, teamID } = info.player;
         // this.verbose(1, 'Disconnected', steamID, playerName, info)
         this.resetPlayerCounters(eosID)


### PR DESCRIPTION
## Summary
- guard against missing player object in `onPlayerDisconnected`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint squad-server/plugins/squad-baiting.js` *(fails: 23 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689de669f610832ea9d35bd9542ee2bb