### PR TITLE
fix: handle missing previous layer in round winner plugin

### DIFF
--- a/squad-server/plugins/discord-round-winner.js
+++ b/squad-server/plugins/discord-round-winner.js
@@ -41,6 +41,11 @@ export default class DiscordRoundWinner extends DiscordBasePlugin {
   }
 
   async onNewGame(info) {
+    const prevLayer = this.server.layerHistory[1]?.layer?.name;
+    const message = prevLayer
+      ? `${info.winner} ${prevLayer} haritasında kazandı.`
+      : `${info.winner} kazandı.`;
+
     await this.sendDiscordMessage({
       embed: {
         title: 'Round Kazanan',
@@ -48,7 +53,7 @@ export default class DiscordRoundWinner extends DiscordBasePlugin {
         fields: [
           {
             name: 'Mesaj',
-            value: `${info.winner} ${this.server.layerHistory[1].layer.name} haritasında kazandı.`
+            value: message
           }
         ],
         timestamp: info.time.toISOString()


### PR DESCRIPTION
## Summary
- handle absent previous layer using optional chaining in Discord round winner plugin
- adjust message when prior map is unknown

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 39 errors)
- `npx eslint squad-server/plugins/discord-round-winner.js`
- `npx prettier --check squad-server/plugins/discord-round-winner.js`


------
https://chatgpt.com/codex/tasks/task_e_689f295234fc832ea199f2cf70a6d50a