### PR TITLE
Avoid EISCONN when connecting RCON twice

### DIFF
--- a/core/__tests__/rcon.test.js
+++ b/core/__tests__/rcon.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'net';
+
+import Rcon from '../rcon.js';
+
+test('connecting twice quickly does not throw EISCONN', async () => {
+  const server = net.createServer();
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+
+  const rcon = new Rcon({ host: '127.0.0.1', port, password: 'pass' });
+  rcon.write = async () => {
+    rcon.loggedin = true;
+  };
+
+  await assert.doesNotReject(async () => {
+    await Promise.all([rcon.connect(), rcon.connect()]);
+  });
+
+  await rcon.disconnect();
+  await new Promise((resolve) => server.close(resolve));
+});


### PR DESCRIPTION
## Summary
- skip redundant RCON connect calls and rebuild socket after it closes
- ensure disconnect fully terminates the socket and resets state
- add regression test for rapid consecutive connects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a727742a2c832ebb29516d41512a07