### PR TITLE
Handle RCON disconnect callbacks safely

### DIFF
--- a/core/rcon.js
+++ b/core/rcon.js
@@ -238,10 +238,17 @@ export default class Rcon extends EventEmitter {
       // IE, Squad server crash, Squad server shutdown for multiple minutes.
 
       while (this.responseCallbackQueue.length > 0) {
-        this.responseCallbackQueue.shift()(new Error('RCON DISCONNECTED'));
+        const callback = this.responseCallbackQueue.shift();
+        try {
+          callback(new Error('RCON DISCONNECTED'));
+        } catch (err) {
+          Logger.verbose('RCON', 1, err);
+        }
       }
       this.callbackIds = [];
     }
+
+    this.emit('RCON_DISCONNECT');
 
     if (this.autoReconnect) {
       Logger.verbose('RCON', 1, `Sleeping ${this.autoReconnectDelay}ms before reconnecting.`);


### PR DESCRIPTION
## Summary
- guard pending callbacks in `onClose` with try/catch and log failures
- emit `RCON_DISCONNECT` when connection closes

## Testing
- `npm test`
- `npx eslint core/rcon.js && echo 'ESLint success'`


------
https://chatgpt.com/codex/tasks/task_e_68ab465b64d8832e8fff9d44e9cb8c15